### PR TITLE
Fix prefpane crash on M1

### DIFF
--- a/prefpane/Jitouch.xcodeproj/project.pbxproj
+++ b/prefpane/Jitouch.xcodeproj/project.pbxproj
@@ -329,6 +329,10 @@
 		1DBD214908BA80EA00186707 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					arm64e,
+				);
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
@@ -348,6 +352,7 @@
 					"$(PROJECT_DIR)",
 				);
 				MARKETING_VERSION = 2.75;
+				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jitouch.${PRODUCT_NAME:identifier}";
 				PRODUCT_NAME = Jitouch;
 				STRIP_INSTALLED_PRODUCT = YES;
@@ -362,6 +367,10 @@
 		1DBD214A08BA80EA00186707 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					arm64e,
+				);
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 2.75;


### PR DESCRIPTION
System Preferences is an x86_64/arm64e universal binary on macOS 12, so arm64 binaries will crash it. Therefore, the prefpane must be built for arm64e as well as x86_64. (Jitouch.app, however, should remain on arm64.)

Tested on an M1 Pro running macOS 12.