### PR TITLE
Fix gesture preview crash on macOS 12

### DIFF
--- a/prefpane/MAAttachedWindow.m
+++ b/prefpane/MAAttachedWindow.m
@@ -330,24 +330,14 @@
 
 - (NSColor *)_backgroundColorPatternImage
 {
-    NSImage *bg = [[NSImage alloc] initWithSize:[self frame].size];
-    NSRect bgRect = NSZeroRect;
-    bgRect.size = [bg size];
-
-    [bg lockFocus];
-    NSBezierPath *bgPath = [self _backgroundPath];
-    [NSGraphicsContext saveGraphicsState];
-    [bgPath addClip];
-
-    // Draw background.
-    [_MABackgroundColor set];
-    [bgPath fill];
-    //[bgPath stroke];
-
-    [NSGraphicsContext restoreGraphicsState];
-    [bg unlockFocus];
-
-    return [NSColor colorWithPatternImage:[bg autorelease]];
+ // TODO: Consider restoring old visual style
+ // using imageWithSize:flipped:drawingHandler e.g.:
+ /*
+    NSImage *bg = [NSImage imageWithSize:[self frame].size
+                                 flipped:NO
+                          drawingHandler:???];
+ */
+    return [NSColor lightGrayColor];  // Return static color for now.
 }
 
 


### PR DESCRIPTION
`[NSView lockFocus]` was [deprecated](http://codeworkshop.net/objc-diff/sdkdiffs/macos/10.14/AppKit.html) in macOS 10.14 and seems to be removed on 12.0.
This PR prevents the prefpane from crashing while trying to show the gesture preview window. It uses a single background color as a substitute for a drawn background, though it is not as pretty.
`imageWithSize:flipped:drawingHandler` is a potential replacement for `lockFocus`, e.g.
```
NSImage *bg = [NSImage imageWithSize:[self frame].size
                                 flipped:NO
                          drawingHandler:???];
```

(Sorry for the several pull requests. I could merge them into an M1+macOS 12 PR, but they seemed like separate issues. Just submitting in case they are helpful to anyone else.)