### PR TITLE
Handle kCGEventTapDisabledByTimeout

### DIFF
--- a/jitouch/Jitouch/Gesture.m
+++ b/jitouch/Jitouch/Gesture.m
@@ -2814,8 +2814,11 @@ static CGEventRef CGEventCallback(CGEventTapProxy proxy, CGEventType type, CGEve
             CGEventSetIntegerValueField(event, kCGMouseEventButtonNumber, 2);
             CGEventSetType(event, kCGEventOtherMouseDragged);
         }
-    } else if (type == kCGEventTapDisabledByUserInput || type == kCGEventTapDisabledByTimeout) {
+    } else if (type == kCGEventTapDisabledByUserInput) {
         CGEventTapEnable(eventTap, true);
+    } else if (type == kCGEventTapDisabledByTimeout) {
+        NSLog(@"kCGEventTapDisabledByTimeout; exiting.");
+        exit(1);
     }
 
 

--- a/jitouch/Jitouch/Gesture.m
+++ b/jitouch/Jitouch/Gesture.m
@@ -2817,8 +2817,23 @@ static CGEventRef CGEventCallback(CGEventTapProxy proxy, CGEventType type, CGEve
     } else if (type == kCGEventTapDisabledByUserInput) {
         CGEventTapEnable(eventTap, true);
     } else if (type == kCGEventTapDisabledByTimeout) {
-        NSLog(@"kCGEventTapDisabledByTimeout; exiting.");
-        exit(1);
+        NSLog(@"Received kCGEventTapDisabledByTimeout; attempting to recreate CGEventTap. Allow Jitouch in System Preferences -> Privacy -> Accessibility.");
+        CFMachPortInvalidate(eventTap);
+        CFRelease(eventTap);
+        CFMachPortRef newEventTap = nil;
+        int i = 0;
+        while (newEventTap == nil) {
+            if (i > 360) {
+                NSLog(@"Could not create CGEventTap");
+                exit(1);
+            }
+            sleep(1);
+            newEventTap = [me createEventTap];
+            i++;
+        }
+        NSLog(@"CGEventTap created");
+        eventTap = newEventTap;
+        return NULL;
     }
 
 
@@ -2893,6 +2908,34 @@ static CGEventRef CGEventCallback(CGEventTapProxy proxy, CGEventType type, CGEve
     }
 
     return event;
+}
+
+- (CFMachPortRef)createEventTap {
+    CGEventMask eventMask;
+    CFRunLoopSourceRef runLoopSource;
+
+    eventMask = CGEventMaskBit(kCGEventScrollWheel) |
+    CGEventMaskBit(kCGEventMouseMoved) |
+    CGEventMaskBit(kCGEventLeftMouseDown) |
+    CGEventMaskBit(kCGEventLeftMouseUp) |
+    CGEventMaskBit(kCGEventRightMouseDown) |
+    CGEventMaskBit(kCGEventRightMouseUp) |
+    CGEventMaskBit(kCGEventOtherMouseDown) |
+    CGEventMaskBit(kCGEventOtherMouseUp) |
+    CGEventMaskBit(kCGEventLeftMouseDragged) |
+    CGEventMaskBit(kCGEventRightMouseDragged) |
+    CGEventMaskBit(kCGEventOtherMouseDragged);
+    //CGEventMaskBit(kCGEventKeyUp) |
+    //CGEventMaskBit(kCGEventKeyDown);
+    CFMachPortRef eventTap = CGEventTapCreate(kCGSessionEventTap, kCGHeadInsertEventTap, 0, eventMask, CGEventCallback, NULL);
+
+    if (eventTap != nil) {
+        CGEventTapEnable(eventTap, true);
+        runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0);
+        CFRunLoopAddSource(CFRunLoopGetMain(), runLoopSource, kCFRunLoopCommonModes);
+    }
+
+    return eventTap;
 }
 
 #pragma mark - Init
@@ -2981,27 +3024,23 @@ static CGEventRef CGEventCallback(CGEventTapProxy proxy, CGEventType type, CGEve
             magicTrackpadRemoved(NULL, magicTrackpadRemovedIterator);
         }
 
-        CGEventMask eventMask;
-        CFRunLoopSourceRef runLoopSource;
-
-        eventMask = CGEventMaskBit(kCGEventScrollWheel) |
-        CGEventMaskBit(kCGEventMouseMoved) |
-        CGEventMaskBit(kCGEventLeftMouseDown) |
-        CGEventMaskBit(kCGEventLeftMouseUp) |
-        CGEventMaskBit(kCGEventRightMouseDown) |
-        CGEventMaskBit(kCGEventRightMouseUp) |
-        CGEventMaskBit(kCGEventOtherMouseDown) |
-        CGEventMaskBit(kCGEventOtherMouseUp) |
-        CGEventMaskBit(kCGEventLeftMouseDragged) |
-        CGEventMaskBit(kCGEventRightMouseDragged) |
-        CGEventMaskBit(kCGEventOtherMouseDragged);
-        //CGEventMaskBit(kCGEventKeyUp) |
-        //CGEventMaskBit(kCGEventKeyDown);
-        eventTap = CGEventTapCreate(kCGSessionEventTap, kCGHeadInsertEventTap, 0, eventMask, CGEventCallback, NULL);
-
-        CGEventTapEnable(eventTap, true);
-        runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0);
-        CFRunLoopAddSource(CFRunLoopGetMain(), runLoopSource, kCFRunLoopCommonModes);
+        eventTap = [me createEventTap];
+        if (eventTap == nil) {
+            NSLog(@"Could not create CGEventTap. Allow Jitouch in System Preferences -> Privacy -> Accessibility.");
+            CFMachPortRef newEventTap = nil;
+            int i = 0;
+            while (newEventTap == nil) {
+                if (i > 360) {
+                    NSLog(@"Could not create CGEventTap");
+                    exit(1);
+                }
+                sleep(1);
+                newEventTap = [me createEventTap];
+                i++;
+            }
+            NSLog(@"CGEventTap created");
+            eventTap = newEventTap;
+        }
 
         gestureWindow = [[GestureWindow alloc] init];
         sizeHistoryDict = [[NSMutableDictionary alloc] init];


### PR DESCRIPTION
If Accessibility permissions are revoked while Jitouch is running, the system UI no longer responds to mouse clicks or key presses. This is due to Jitouch's `CGEventTap` callback that receives user input events but cannot pass them along due to a lack of permissions. For more about this issue see aaronkollasch#5.

After a delay, the OS normally detects the `CGEventTap` has timed out and sends a `kCGEventTapDisabledByTimeout` event to Jitouch's `CGEventCallback`. However, this event was ignored, allowing Jitouch to continue dropping all mouse and keyboard events.

With this pull request, if CGEventCallback receives a kCGEventTapDisabledByTimeout event, it will trigger Jitouch to remove the `CGEventTap` and try to create another for 5 minutes, then exit if one still can't be created.

This PR supersedes #2.

See:
- https://developer.apple.com/documentation/coregraphics/1455445-cgeventtapenable
- https://developer.apple.com/documentation/coregraphics/cgeventtype?language=objc
- http://mirror.informatimago.com/next/developer.apple.com/documentation/Carbon/Reference/QuartzEventServicesRef/QuartzEventServicesRef.pdf